### PR TITLE
Make specs pass

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,3 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in grape-swagger-representable.gemspec
 gemspec
-
-gem 'grape-swagger', github: 'ruby-grape/grape-swagger'

--- a/grape-swagger-representable.gemspec
+++ b/grape-swagger-representable.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rack-test'
   s.add_development_dependency 'rack-cors'
   s.add_development_dependency 'rubocop'
+  s.add_development_dependency 'multi_json'
   s.add_development_dependency 'redcarpet' unless RUBY_PLATFORM.eql?('java') || RUBY_ENGINE.eql?('rbx')
   s.add_development_dependency 'rouge' unless RUBY_PLATFORM.eql?('java') || RUBY_ENGINE.eql?('rbx')
   s.add_development_dependency 'pry' unless RUBY_PLATFORM.eql?('java') || RUBY_ENGINE.eql?('rbx')


### PR DESCRIPTION
* Add `multi_json` dev dependency to fix `Missing dependency 'multi_json' for Representable::JSON` error
    * cf. https://github.com/ruby-grape/grape/blob/master/CHANGELOG.md#100-732017
* Remove grape-swagger dependency from Gemfile to fix failing specs due to https://github.com/ruby-grape/grape-swagger/pull/631