### PR TITLE
Enum as proc

### DIFF
--- a/lib/grape-swagger/representable/parser.rb
+++ b/lib/grape-swagger/representable/parser.rb
@@ -41,6 +41,9 @@ module GrapeSwagger
             memo[:type] = data_type
           end
 
+          default_value = documentation[:default] || property[:default] || nil
+          memo[:default] = default_value unless default_value.nil?
+
           values = documentation[:values] || property[:values] || nil
           memo[:enum] = values.is_a?(Proc) ? values.call : values if values
 

--- a/lib/grape-swagger/representable/parser.rb
+++ b/lib/grape-swagger/representable/parser.rb
@@ -42,7 +42,7 @@ module GrapeSwagger
           end
 
           values = documentation[:values] || property[:values] || nil
-          memo[:enum] = values if values.is_a?(Array)
+          memo[:enum] = values.is_a?(Proc) ? values.call : values if values
 
           example = documentation[:example] || property[:example] || nil
           memo[:example] = example.is_a?(Proc) ? example.call : example if example

--- a/spec/grape-swagger/representers/response_inline_representer_spec.rb
+++ b/spec/grape-swagger/representers/response_inline_representer_spec.rb
@@ -21,7 +21,7 @@ describe 'responseInlineModel' do
         class Error < Representable::Decorator
           include Representable::JSON
 
-          property :code, documentation: { type: 'string', desc: 'Error code' }
+          property :code, default: 403, documentation: { type: 'string', desc: 'Error code' }
           property :message, documentation: { type: 'string', desc: 'Error message' }
         end
 
@@ -39,7 +39,7 @@ describe 'responseInlineModel' do
             property :id, documentation: { required: true }
           end
           collection :tags, decorator: ThisInlineApi::Representers::Tag, documentation: { desc: 'Tags.' } do
-            property :color, documentation: { type: String, desc: 'Tag color.' }
+            property :color, documentation: { type: String, desc: 'Tag color.', values: -> { %w[red blue green] }, default: 'red' }
           end
         end
       end
@@ -116,7 +116,7 @@ describe 'responseInlineModel' do
       'type' => 'object',
       'description' => 'This returns something',
       'properties' => {
-        'code' => { 'type' => 'string', 'description' => 'Error code' },
+        'code' => { 'type' => 'string', 'description' => 'Error code', 'default' => 403 },
         'message' => { 'type' => 'string', 'description' => 'Error message' }
       }
     )
@@ -157,7 +157,12 @@ describe 'responseInlineModel' do
             'type' => 'object',
             'properties' => {
               'name' => { 'description' => 'Name', 'type' => 'string', 'example' => 'A tag' },
-              'color' => { 'description' => 'Tag color.', 'type' => 'string' }
+              'color' => {
+                'description' => 'Tag color.',
+                'type' => 'string',
+                'enum' => %w[red blue green],
+                'default' => 'red'
+              }
             }
           },
           'description' => 'Tags.'


### PR DESCRIPTION
Enums can be dynamic like aasm_state or items in database, so if representer have documentation with calls to db it will affect speed of representer. It is better to have proc to defer reading enum property.

Now that I think about this. It will be better to documentation property as proc. What do you think?